### PR TITLE
アクセストークンの暗号化およびリフレッシュトークンのハッシュ化実装

### DIFF
--- a/app/controllers/google_calendars_controller.rb
+++ b/app/controllers/google_calendars_controller.rb
@@ -1,0 +1,11 @@
+class GoogleCalendarsController < ApplicationController
+  require 'google/apis/calendar_v3'
+  require 'googleauth'
+
+  class GoogleCalendarService
+    def initialize
+      @client = Google::Apis::CalendarV3::CalendarService.new
+      @client.authorization = user.google_oauth_token
+    end
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -10,8 +10,14 @@ class SessionsController < ApplicationController
     access_token = user_info['credentials']['token']
     refresh_token = user_info['credentials']['refresh_token']
 
-    hashed_access_token = UserAuthentication.hash_token(access_token)
+    # hashed_access_token = UserAuthentication.hash_token(access_token) #暗号化に切り替え
     hashed_refresh_token = UserAuthentication.hash_token(refresh_token) if refresh_token
+    # p "-------------------------------------------"
+    # p "google_image" => user_info['info']['image']
+    # p "access_token: #{access_token}"
+    # p "refresh_token: #{refresh_token}"
+    # p "hashed_refresh_token: #{hashed_refresh_token}"
+    # p "-------------------------------------------"
 
     user_authentication = UserAuthentication.find_by(uid: google_user_id, provider: provider)
 
@@ -19,17 +25,17 @@ class SessionsController < ApplicationController
       Rails.logger.info("User already exists")
       if refresh_token == nil
         Rails.logger.info("Refresh token is nil")
-        user_authentication.update(access_token: hashed_access_token)
+        user_authentication.update(access_token: access_token)
       else
         Rails.logger.info("Refresh token is exist")
-        user_authentication.update(access_token: hashed_access_token, refresh_token: hashed_refresh_token)
+        user_authentication.update(access_token: access_token, refresh_token: hashed_refresh_token)
       end
 
       redirect_to "#{frontend_url}/?token=#{token}",allow_other_host: true
     else
       Rails.logger.info("User does not exist")
-      user = User.create(name: user_info['info']['name'], email:user_info['info']['email'])
-      UserAuthentication.create( user_id: user.id, uid: google_user_id, provider: provider)
+      user = User.create(name: user_info['info']['name'], email:user_info['info']['email'], image: user_info['info']['image'])
+      UserAuthentication.create( user_id: user.id, uid: google_user_id, provider: provider, access_token: access_token, refresh_token: hashed_refresh_token)
       redirect_to "#{frontend_url}/?token=#{token}", allow_other_host: true
     end
   end

--- a/app/models/user_authentication.rb
+++ b/app/models/user_authentication.rb
@@ -4,5 +4,7 @@ class UserAuthentication < ApplicationRecord
     Digest::SHA256.hexdigest(token)
   end
 
+  encrypts :access_token #access_tokenを暗号化 (refresh_tokenは暗号化ではなくハッシュ化。再利用しないため)
+
   belongs_to :user, dependent: :destroy
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,6 +36,10 @@ module App
     config.middleware.use ActionDispatch::Cookies # クライアントとのやりとりでCookieを扱えるようにする。
     config.middleware.use ActionDispatch::Session::CookieStore, key: "_my_calender_app_session" # sessionメソッドを扱えるようにする（セッションデータを暗号化してCookieに保存する）
 
+    config.active_record.encryption.primary_key = ENV["ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY"]
+    config.active_record.encryption.deterministic_key = ENV["ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY"]
+    config.active_record.encryption.key_derivation_salt = ENV["ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT"]
+
     config.generators do |g|
       g.assets false
       g.skip_routes true

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -2,6 +2,6 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   provider :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_CLIENT_SECRET'],
   scope: 'userinfo.email, userinfo.profile, openid, https://www.googleapis.com/auth/calendar.events.owned',
   access_type: 'offline'
-  # prompt: 'consent' #一時的に追加
+  # prompt: 'consent' #リフレッシュトークンを登録するとき、一時的に追加
 end
 OmniAuth.config.allowed_request_methods = [:post, :get]


### PR DESCRIPTION
セッションログイン時のアクセストークンの登録時に暗号化するようにしました。
また、リフレッシュトークンは引き続きハッシュ化して登録するようにしております。