### PR TITLE
Connect google cale

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,6 @@ gem 'jwt'
 
 gem 'dotenv', groups: [:development, :test]
 
-# group :development do
-#   gem 'pry-byebug'
-# end
+group :development do
+  gem 'pry-byebug'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -56,3 +56,7 @@ gem 'omniauth-rails_csrf_protection'
 gem 'jwt'
 
 gem 'dotenv', groups: [:development, :test]
+
+# group :development do
+#   gem 'pry-byebug'
+# end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,8 @@ GEM
     bootsnap (1.18.4)
       msgpack (~> 1.2)
     builder (3.3.0)
+    byebug (12.0.0)
+    coderay (1.1.3)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
     crass (1.0.6)
@@ -150,6 +152,7 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.4)
+    method_source (1.1.0)
     mini_mime (1.1.5)
     minitest (5.25.5)
     msgpack (1.8.0)
@@ -202,6 +205,12 @@ GEM
     pp (0.6.2)
       prettyprint
     prettyprint (0.2.0)
+    pry (0.15.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.11.0)
+      byebug (~> 12.0)
+      pry (>= 0.13, < 0.16)
     psych (5.2.3)
       date
       stringio
@@ -301,6 +310,7 @@ DEPENDENCIES
   omniauth-google-oauth2
   omniauth-rails_csrf_protection
   pg (~> 1.1)
+  pry-byebug
   puma (>= 5.0)
   rack-cors
   rails (~> 7.1.5, >= 7.1.5.1)

--- a/app/controllers/google_calendars_controller.rb
+++ b/app/controllers/google_calendars_controller.rb
@@ -3,9 +3,34 @@ class GoogleCalendarsController < ApplicationController
   require 'googleauth'
 
   class GoogleCalendarService
-    def initialize
-      @client = Google::Apis::CalendarV3::CalendarService.new
-      @client.authorization = user.google_oauth_token
+    def initialize(user)
+      @calendar = Google::Apis::CalendarV3::CalendarService.new
+      if user.user_authentication.nil?
+        raise "UserAuthentication is missing for user: #{user.id}"
+      end
+      @calendar.authorization =  user.user_authentication.access_token  ##-- あとでcurrent_userから取得するように修正.--##
+      # アプリケーションの名前を設定（GCPで設定したサービスアカウント名）
+      @calendar.client_options.application_name = ENV['GOOGLE_CALENDAR_APPLICATION_NAME']
+      # 利用するカレンダーのID(GCPで設定したメールアドレス)を設定する
+      @calendar_id = user.email
+      # puts "Google Calendar API initialized"
+    end
+
+    def client
+      @calendar
+    end
+
+    def read
+      events = @calendar.list_events(@calendar_id,
+      time_min: Time.new(2025,3,27).iso8601,
+      time_max: Time.new(2025,3,28).iso8601,)
+      puts "--------------------event-----------------------"
+      puts events.items.inspect
+      puts "--------------------event-----------------------"
+      # events.items.each do |event|
+      #   puts '-------------------------------'
+      #   puts_event(event)
+      # end
     end
   end
 end


### PR DESCRIPTION
ログイン中のgoogleアカウントに紐づくカレンダーを取得できるようにGoogleカレンダー認証方法を変更しました。
変更前：サービスアカウントのcredentialを用いて認証
変更後：OAuthから取得したgoogleのaccess tokenを用いて認証